### PR TITLE
add blockExplorerUrls

### DIFF
--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -54,6 +54,7 @@ export const AddKakarotNetwork = () => (
             decimals: 18,
           },
           rpcUrls: ["https://sepolia-rpc.kakarot.org"],
+          blockExplorerUrls: ["https://sepolia.kakarotscan.org"],
         },
       ];
       try {


### PR DESCRIPTION
`🦊 Add Kakarot Sepolia to Metamask 🦊` button **doesn't include block explorer** when it's clicked by a user, I think it's important to **include the block explorer** when a user adds a network to Rabby/MetaMask/etc.