### PR TITLE
fix: explorer url

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -55,7 +55,7 @@ export const AddKakarotNetwork = () => (
           },
           rpcUrls: ["https://sepolia-rpc.kakarot.org"],
           blockExplorerUrls: [
-            "https://sepolia.kakarotscan.org",
+            "https://sepolia.kakarotscan.org/",
             "https://sepolia-blockscout.kakarot.org",
           ],
         },
@@ -88,7 +88,7 @@ Or by add a new network manually to Metamask: open the Metamask extension. Click
 | RPC URL        | https://sepolia-rpc.kakarot.org |
 | Chain Id       | 1802203764                      |
 | Symbol         | ETH                             |
-| Block Explorer | https://sepolia.kakarotscan.org |
+| Block Explorer | https://sepolia.kakarotscan.org/ |
 
 ### As a developer, how can I build on Kakarot zkEVM?
 

--- a/docs/survival-guide.md
+++ b/docs/survival-guide.md
@@ -17,7 +17,7 @@ the necessary links and information to navigate the Testnet well.
 ### Testnet Tools
 
 - Explorers:
-  - Routescan: https://sepolia.kakarotscan.org
+  - Routescan: https://sepolia.kakarotscan.org/
   - Blockscout: https://sepolia-blockscout.kakarot.org
 - Public RPC: https://sepolia-rpc.kakarot.org
 


### PR DESCRIPTION
add an ending `/` because some wallets _hum hum TrustWallet_ doesn't add the `/` between the root domain and a subroute when linking to explorer