### PR TITLE
docs: fix invalid links

### DIFF
--- a/docs/architecture/understanding-kakarot.md
+++ b/docs/architecture/understanding-kakarot.md
@@ -33,7 +33,7 @@ Starknet, as well as better interoperability with the broader Ethereum
 ecosystem.
 
 Discover the Kakarot explorer and other useful links on the
-[survival guide](../survival-guide) page.
+[survival guide](../survival-guide.md) page.
 
 Note: Kakarot is not a privacy chain. Zero-knowledge technologies can be used
 for two (non-excluding) purposes, Scaling or Privacy. Kakarot uses the former to

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -122,4 +122,4 @@ In case you encounter some unknown bug or want to discuss new features, you can:
    100-1,000x improvements in ZK proof generation performance.
 
 For a deep-dive into the Kakarot design, check out
-[the architecture overview](architecture/understanding-zkevm).
+[the architecture overview](architecture/understanding-zkevm.md).


### PR DESCRIPTION
Found the document with the wrong link path and corrected it. Added the ‘.md’ extension to the link path.